### PR TITLE
Bump to v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Returns current castling rights for each player.
 
 Makes the active player play the provided algebraic notation move if possible. If successful, returns null. If unsuccessful, returns an Error object.
 
+### toNthPosition(n: number): Chess
+
+Moves to specified history state (0-indexed) if available, and loads all position details (e.g. active player, half moves etc.) of that position. Sets latest position if n is greater or equal to the history length, and sets first position if n is less than 0. Mutates instance and returns `this`.
+
 ### toPreviousPosition(): Chess
 
 Moves history back one position if available, and loads all position details (e.g. active player, half moves etc.) of that position. Mutates instance and returns `this`.
@@ -74,9 +78,13 @@ Moves history back one position if available, and loads all position details (e.
 
 Moves history forward one position if available, and loads all position details (e.g. active player, half moves etc.) of that position. Mutates instance and returns `this`.
 
-### toPGN(): string
+### toPGN(opts: { movesOnly: boolean }): string
 
 Serialises full game history to a string in PGN format.
+
+#### opts.movesOnly (optional; default: false)
+
+A boolean - if true, will omit tag pairs from the PGN.
 
 ### toFEN(): string
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const chessFromPGN = new Chess(
 
 ### constructor(startingState?: string, opts?: { isPGN: boolean })
 
-Will throw if the resulting FEN string is invalid (e.g. not a 8x8 board position, missing segments etc.).
+Will throw if given PGN and it contains an invalid move, or the resulting starting FEN string is invalid (e.g. not a 8x8 board position, missing segments etc.).
 
 #### startingState (optional)
 
@@ -62,9 +62,9 @@ Returns full move count for current position.
 
 Returns current castling rights for each player.
 
-### playMove(move: string): void
+### playMove(move: string): Error | null
 
-Makes the active player play the provided algebraic notation move if possible.
+Makes the active player play the provided algebraic notation move if possible. If successful, returns null. If unsuccessful, returns an Error object.
 
 ### toPreviousPosition(): Chess
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maoshizhong/chess",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "author": "MaoShizhong",
     "description": "Simple code-only Chessboard written in TypeScript. Handles FEN and PGN.",
     "repository": {

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -96,7 +96,7 @@ export class ChessHistory {
         return Object.values(this.#positionCounts).some((count) => count === 3);
     }
 
-    toPGN(): string {
-        return PGN.serialise(this.#history);
+    toPGN(movesOnly: boolean): string {
+        return PGN.serialise(this.#history, movesOnly);
     }
 }

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -47,6 +47,18 @@ export class ChessHistory {
         };
     }
 
+    toNthState(n: number): HistoryState {
+        if (0 <= n && n < this.length) {
+            this.#currentIndex = n;
+        } else if (n < 0) {
+            this.#currentIndex = 0;
+        } else {
+            this.#currentIndex = this.length - 1;
+        }
+
+        return this.currentState;
+    }
+
     toPreviousState(): HistoryState {
         const hasPreviousState = this.#currentIndex > 0;
         if (hasPreviousState) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -354,6 +354,44 @@ describe('Constructing from PGN', () => {
     });
 });
 
+describe('Serialising to PGN', () => {
+    it('Serialises full game to PGN', () => {
+        const chess = new Chess(STARTING_POSITION);
+        chess.playMove('e4');
+        chess.playMove('e5');
+        chess.playMove('d4');
+        expect(chess.toPGN()).toBe('1. e4 e5 2. d4');
+
+        const chess2 = new Chess(
+            'rnb1kbnr/ppp1pppp/8/3q4/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3'
+        );
+        chess2.playMove('Nf3');
+        chess2.playMove('Bg4');
+        chess2.playMove('Be2');
+        expect(chess2.toPGN()).toBe(
+            '[SetUp "1"]\n[FEN "rnb1kbnr/ppp1pppp/8/3q4/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3"]\n\n3. Nf3 Bg4 4. Be2'
+        );
+    });
+
+    it('Omits tag pairs from PGN if requested', () => {
+        const chess = new Chess(
+            'rnb1kbnr/ppp1pppp/8/3q4/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3'
+        );
+        chess.playMove('Nf3');
+        chess.playMove('Bg4');
+        chess.playMove('Be2');
+        expect(chess.toPGN({ movesOnly: true })).toBe('3. Nf3 Bg4 4. Be2');
+
+        const chess2 = new Chess(
+            'rnbqkbnr/ppp1pppp/8/3P4/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2'
+        );
+        chess2.playMove('Qxd5');
+        chess2.playMove('Nf3');
+        chess2.playMove('Bg4');
+        expect(chess2.toPGN({ movesOnly: true })).toBe('2... Qxd5 3. Nf3 Bg4');
+    });
+});
+
 describe('Error reporting', () => {
     it('Throws if provided PGN contains invalid moves', () => {
         expect(() => new Chess('1. e4 e5 2. e5', { isPGN: true })).toThrow(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -353,3 +353,37 @@ describe('Constructing from PGN', () => {
         expect(chess2.history.length).toBe(2);
     });
 });
+
+describe('Error reporting', () => {
+    it('Throws if provided PGN contains invalid moves', () => {
+        expect(() => new Chess('1. e4 e5 2. e5', { isPGN: true })).toThrow(
+            'Invalid PGN - could not play e5'
+        );
+
+        expect(() => new Chess('1. e7', { isPGN: true })).toThrow(
+            'Invalid PGN - could not play e7'
+        );
+    });
+
+    it('Returns null if move successfully played', () => {
+        const chess = new Chess(STARTING_POSITION);
+        const e4Result = chess.playMove('e4');
+        expect(e4Result).toBe(null);
+
+        const e5Result = chess.playMove('e5');
+        expect(e5Result).toBe(null);
+    });
+
+    it('Returns error if move not played', () => {
+        const chess = new Chess(STARTING_POSITION);
+        const Kd1Result = chess.playMove('Kd1');
+        expect(Kd1Result).toBeInstanceOf(Error);
+        expect(Kd1Result?.message).toBe('Kd1 is not a valid move');
+
+        // https://lichess.org/analysis/8/8/8/8/2k5/1q6/8/K7_w_-_-_0_1
+        const chess2 = new Chess('8/8/8/8/2k5/1q6/8/K7 w - - 0 1');
+        const Kb1Result = chess.playMove('Kb1');
+        expect(Kb1Result).toBeInstanceOf(Error);
+        expect(Kb1Result?.message).toBe('Kb1 is not a valid move');
+    });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -420,7 +420,7 @@ describe('Error reporting', () => {
 
         // https://lichess.org/analysis/8/8/8/8/2k5/1q6/8/K7_w_-_-_0_1
         const chess2 = new Chess('8/8/8/8/2k5/1q6/8/K7 w - - 0 1');
-        const Kb1Result = chess.playMove('Kb1');
+        const Kb1Result = chess2.playMove('Kb1');
         expect(Kb1Result).toBeInstanceOf(Error);
         expect(Kb1Result?.message).toBe('Kb1 is not a valid move');
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,11 @@ class Chess {
         return this;
     }
 
+    toNthPosition(n: number): Chess {
+        this.#loadPosition(this.history.toNthState(n));
+        return this;
+    }
+
     toPGN(): string {
         return this.history.toPGN();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,12 @@ class Chess {
         return this;
     }
 
-    toPGN(): string {
-        return this.history.toPGN();
+    toPGN({ movesOnly } = { movesOnly: false }): string {
+        const fullPGN = this.history.toPGN();
+        const movesList = fullPGN
+            .substring(fullPGN.lastIndexOf(']') + 1)
+            .trim();
+        return movesOnly ? movesList : fullPGN;
     }
 
     toFEN(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,11 +161,7 @@ class Chess {
     }
 
     toPGN({ movesOnly } = { movesOnly: false }): string {
-        const fullPGN = this.history.toPGN();
-        const movesList = fullPGN
-            .substring(fullPGN.lastIndexOf(']') + 1)
-            .trim();
-        return movesOnly ? movesList : fullPGN;
+        return this.history.toPGN(movesOnly);
     }
 
     toFEN(): string {

--- a/src/parsers/PGN.ts
+++ b/src/parsers/PGN.ts
@@ -1,13 +1,16 @@
 import { History } from '../types';
 import * as FEN from './FEN';
 
-export function serialise(history: History): string {
+export function serialise(history: History, movesOnly: boolean): string {
     const [{ FEN: startingFEN }, ...moves] = history;
     const isStandardStart =
         startingFEN ===
         'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
-    let PGN = isStandardStart ? '' : `[SetUp "1"]\n[FEN "${startingFEN}"]\n\n`;
+    let PGN =
+        isStandardStart || movesOnly
+            ? ''
+            : `[SetUp "1"]\n[FEN "${startingFEN}"]\n\n`;
 
     const startingFullMoves = Number(startingFEN.split(' ').at(-1)) - 1;
 

--- a/src/parsers/PGN.ts
+++ b/src/parsers/PGN.ts
@@ -1,7 +1,10 @@
 import { History } from '../types';
 import * as FEN from './FEN';
 
-export function serialise(history: History, movesOnly: boolean): string {
+export function serialise(
+    history: History,
+    movesOnly: boolean = false
+): string {
     const [{ FEN: startingFEN }, ...moves] = history;
     const isStandardStart =
         startingFEN ===

--- a/src/parsers/PGN.ts
+++ b/src/parsers/PGN.ts
@@ -17,7 +17,8 @@ export function serialise(history: History): string {
         if (i === 0 && nextPlayer === 'w') {
             PGN += `${startingFullMoves + 1}... `;
         } else if (nextPlayer === 'b') {
-            const moveNumber = i / 2 + 1 + startingFullMoves;
+            // Without Math.ceil, if first move is by black then the next move is numbered with .5
+            const moveNumber = Math.ceil(i / 2 + 1 + startingFullMoves);
             PGN += `${moveNumber}. `;
         }
 


### PR DESCRIPTION
### This PR

- Adds `toNthPosition()` method
- Allows optional omission of tag pairs from PGN serialisation
- Returns success result from `playMove()`
- Throws on instantiation if initial PGN contains invalid move
- Fixes PGN serialisation with move numbers if first move is by black
- Bumps to v1.1.0