### PR TITLE
(v1.2.0 release) Allow from/to coordinates to be passed to `playMove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,25 @@ const chessFromPGN = new Chess(
     [FEN "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/2N5/PPPP1PPP/R1BQKBNR w KQkq - 2 3"]
 
     3. Bc4 Bc5 4. Qg4 Kf8 5. Qf3 Nf6 6. Nge2 d6 7. h3
-`,
+    `,
     { isPGN: true }
 );
+
+// Play moves - player switching/castling rights handled automatically
+chess.playMove('e4');
+chess.playMove('e5');
+chess.playMove('d4');
+chess.playMove('exd4');
+
+// Instead of algebraic moves, moves can be passed as "from" coordinate and "to" coordinate
+chess.playMove({ from: 'g1', to: 'f3' });
+chess.playMove({ from: 'b8', to: 'c6' });
+chess.playMove({ from: 'b1', to: 'd2' });
+
+// Get the PGN
+console.log(chess.toPGN()); // 1. e4 e5 2. d4 exd4 3. Nf3 Nc6 4. Nbd2
+// Get the current position's FEN
+console.log(chess.toFEN()); // r1bqkbnr/pppp1ppp/2n5/8/3pP3/5N2/PPPN1PPP/R1BQKB1R b KQkq - 3 4
 ```
 
 ## Methods
@@ -62,9 +78,11 @@ Returns full move count for current position.
 
 Returns current castling rights for each player.
 
-### playMove(move: string): Error | null
+### playMove(move: string | { from: string, to: string }): Error | null
 
-Makes the active player play the provided algebraic notation move if possible. If successful, returns null. If unsuccessful, returns an Error object.
+Makes the active player play the provided move if possible. If successful, returns null. If unsuccessful, returns an Error object.
+
+Moves can be provided as a full algebraic move as a string (e.g. 'e4' / 'Nf3' / 'Bxc6' / 'O-O') or as an object with a "from" coordinate and "to" coordinate, given in algebraic notation (e.g. { from: 'e1', to: 'g1' }). If given as an object, the resulting algebraic move will automatically include any castling, capture or disambiguating information.
 
 ### toNthPosition(n: number): Chess
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chess-ts",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chess-ts",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maoshizhong/chess",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "author": "MaoShizhong",
     "description": "Simple code-only Chessboard written in TypeScript. Handles FEN and PGN.",
     "repository": {

--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -1,0 +1,65 @@
+import { expect, it } from 'vitest';
+import { Chess } from '.';
+
+it('Plays a full game', () => {
+    const chess = new Chess();
+    chess.playMove('e4');
+    chess.playMove('e5');
+    chess.playMove('Bc4');
+    chess.playMove('Nc6');
+
+    expect(chess.toPGN()).toBe('1. e4 e5 2. Bc4 Nc6');
+    expect(chess.toFEN()).toBe(
+        'r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/8/PPPP1PPP/RNBQK1NR w KQkq - 2 3'
+    );
+
+    chess.playMove('Qh5');
+    chess.playMove('a6');
+    chess.playMove('Qxf7'); // checkmate, white wins
+
+    expect(chess.toPGN()).toBe('1. e4 e5 2. Bc4 Nc6 3. Qh5 a6 4. Qxf7# 1-0');
+    expect(chess.toFEN()).toBe(
+        'r1bqkbnr/1ppp1Qpp/p1n5/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4'
+    );
+});
+
+it('Prevents post-game-end moves being played', () => {
+    const chess = new Chess();
+    chess.playMove('e4');
+    chess.playMove('e5');
+    chess.playMove('Bc4');
+    chess.playMove({ from: 'b8', to: 'c6' });
+    chess.playMove('Qh5');
+    chess.playMove('a6');
+    chess.playMove('Qxf7'); // checkmate, white wins
+
+    chess.playMove('Ke7');
+    chess.playMove({ from: 'f2', to: 'f4' });
+
+    expect(chess.toPGN()).toBe('1. e4 e5 2. Bc4 Nc6 3. Qh5 a6 4. Qxf7# 1-0');
+    expect(chess.toFEN()).toBe(
+        'r1bqkbnr/1ppp1Qpp/p1n5/4p3/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 4'
+    );
+});
+
+it('Continues from a game midway', () => {
+    // https://lichess.org/analysis/standard/r1bqkbnr/pppp1ppp/2n5/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR_b_KQkq_-_3_3
+    const chess = new Chess(
+        'r1bqkbnr/pppp1ppp/2n5/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 3 3'
+    );
+    chess.playMove({ from: 'g7', to: 'g6' });
+    chess.playMove({ from: 'h5', to: 'f3' });
+    chess.playMove('Nf6');
+    chess.playMove('Ne2');
+    chess.playMove('Bc5');
+    chess.playMove({ from: 'e1', to: 'g1' });
+    chess.playMove({ from: 'f6', to: 'e4' });
+    chess.playMove({ from: 'f3', to: 'f7' }); // checkmate, white wins
+
+    expect(chess.toPGN()).toBe(
+        '[SetUp "1"]\n[FEN "r1bqkbnr/pppp1ppp/2n5/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 3 3"]\n\n3... g6 4. Qf3 Nf6 5. Ne2 Bc5 6. O-O Nxe4 7. Qxf7# 1-0'
+    );
+    expect(chess.toFEN()).toBe(
+        'r1bqk2r/pppp1Q1p/2n3p1/2b1p3/2B1n3/8/PPPPNPPP/RNB2RK1 b kq - 0 7'
+    );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,15 @@ import {
     CastlingRights,
     HistorySegments,
     HistoryState,
+    MoveCoordinates,
     Players,
     Result,
 } from './types';
 import { Chessboard } from './board/board';
+import { ChessHistory } from './history/history';
 import * as FEN from './parsers/FEN';
 import * as PGN from './parsers/PGN';
-import { ChessHistory } from './history/history';
+import * as algebraic from './parsers/algebraic';
 
 class Chess {
     history: ChessHistory;
@@ -73,10 +75,17 @@ class Chess {
         };
     }
 
-    playMove(algebraicMove: string): Error | null {
+    playMove(move: string | MoveCoordinates): Error | null {
+        // TODO: replace falsy expression with coordinates->toAlgebraic method call
+        const [couldConvertToAlgebraic, algebraicMove] =
+            typeof move === 'string'
+                ? [true, move]
+                : algebraic.toFullAlgebraicMove(move, this.board);
+
         const invalidMoveError = new Error(
-            `${algebraicMove} is not a valid move`
+            `${couldConvertToAlgebraic ? algebraicMove : move} is not a valid move`
         );
+
         if (!this.isGameInPlay) {
             return invalidMoveError;
         }

--- a/src/parsers/algebraic.test.ts
+++ b/src/parsers/algebraic.test.ts
@@ -270,7 +270,7 @@ describe('Parsing algebraic notation', () => {
     });
 });
 
-describe.only('Converting to algebraic notation', () => {
+describe('Converting to algebraic notation', () => {
     it.each([
         [4, 'a', 'a4'],
         [7, 'c', 'c7'],

--- a/src/parsers/algebraic.test.ts
+++ b/src/parsers/algebraic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as algebraic from './algebraic';
-import { RANK, FILE } from '../board/board';
+import { RANK, FILE, Chessboard } from '../board/board';
 
 describe('Parsing algebraic notation', () => {
     describe('Non-captures', () => {
@@ -270,7 +270,7 @@ describe('Parsing algebraic notation', () => {
     });
 });
 
-describe('Converting to algebraic notation', () => {
+describe.only('Converting to algebraic notation', () => {
     it.each([
         [4, 'a', 'a4'],
         [7, 'c', 'c7'],
@@ -284,4 +284,38 @@ describe('Converting to algebraic notation', () => {
             );
         }
     );
+
+    describe('Converting move coordinates to algebraic move when given a board', () => {
+        const boards: { [key: string]: Chessboard } = {
+            'starting board': new Chessboard(
+                'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR'
+            ),
+            // https://lichess.org/analysis/r3k3/8/8/8/8/8/8/4K2R_w_Kq_-_0_1
+            'castling board': new Chessboard('r3k3/8/8/8/8/8/8/4K2R'),
+            // https://lichess.org/analysis/r3k3/1q6/1N6/8/5p2/6P1/8/2B1K2R_w_Kq_-_0_1
+            'open board': new Chessboard('r3k3/1q6/1N6/8/5p2/6P1/8/2B1K2R'),
+            // https://lichess.org/analysis/2r1k3/8/8/4p3/2N1Q1NQ/2r5/8/3K3Q_w_-_-_0_1
+            'disambiguating board': new Chessboard(
+                '2r1k3/8/8/4p3/2N1Q1NQ/2r5/8/3K3Q'
+            ),
+        };
+
+        it.each([
+            ['g1', 'f3', 'Nf3', 'starting board'],
+            ['a2', 'a3', 'a3', 'starting board'],
+            ['e1', 'g1', 'O-O', 'castling board'],
+            ['e8', 'c8', 'O-O-O', 'castling board'],
+            ['e1', 'e2', 'Ke2', 'open board'],
+            ['c1', 'f4', 'Bxf4', 'open board'],
+            ['f4', 'g3', 'fxg3', 'open board'],
+            ['b7', 'b6', 'Qxb6', 'open board'],
+            ['c4', 'e5', 'Ncxe5', 'disambiguating board'],
+            ['c3', 'c4', 'R3xc4', 'disambiguating board'],
+            ['h4', 'e1', 'Qh4e1', 'disambiguating board'],
+        ])('Converts %s->%s to %s on the %s', (from, to, result, board) => {
+            expect(
+                algebraic.toFullAlgebraicMove({ from, to }, boards[board])
+            ).toEqual([true, result]);
+        });
+    });
 });

--- a/src/parsers/algebraic.ts
+++ b/src/parsers/algebraic.ts
@@ -33,7 +33,7 @@ export function toFullAlgebraicMove(
         return [false, ''];
     }
 
-    let pieceLetter = pieceToMove.letter.toUpperCase();
+    const pieceLetter = pieceToMove.letter.toUpperCase();
     if (pieceLetter === 'P') {
         return [true, isCapture ? `${from[0]}x${to}` : to];
     } else if (pieceLetter === 'K' && fromFile - toFile === 2) {
@@ -76,7 +76,7 @@ export function toFullAlgebraicMove(
 
     return [
         true,
-        `${pieceToMove.letter.toUpperCase()}${fileDisambiguator}${rankDisambiguator}${isCapture ? 'x' : ''}${to}`,
+        `${pieceLetter}${fileDisambiguator}${rankDisambiguator}${isCapture ? 'x' : ''}${to}`,
     ];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export type HistoryState = {
     fullMoves: number;
 };
 
-// Number relative to current position, not the same as CoordinateNumber
+// Number relative to current position, not the same as Coordinate
 export type Move = [number, number];
 // Moves organised by blockable direction to facilitate valid move filtering
 export type SameDirectionMoves = Move[];
@@ -86,3 +86,9 @@ export type MoveInfo = {
     promoteTo?: PromotionPieceLetter;
 };
 export type PlayerMoveInfo = MoveInfo & { colour: Colour };
+
+// e.g. { from: 'g1', to: 'f3' }
+export type MoveCoordinates = {
+    from: string;
+    to: string;
+};


### PR DESCRIPTION
## This PR

- Allows algebraic from/to coordinates to be passed to `playMove` instead of the full algebraic move (which can still be passed). Castling/disambiguations handled automatically.
- Adds full game integration test file.
- Updates README with new API and examples.
- Bumps minor version number.