### PR TITLE
(v1.2.1 release) Fix failed coordinate->algebraic conversion not returning early with error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chess-ts",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chess-ts",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maoshizhong/chess",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": "MaoShizhong",
     "description": "Simple code-only Chessboard written in TypeScript. Handles FEN and PGN.",
     "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ class Chess {
             `${couldConvertToAlgebraic ? algebraicMove : move} is not a valid move`
         );
 
-        if (!this.isGameInPlay) {
+        if (!couldConvertToAlgebraic || !this.isGameInPlay) {
             return invalidMoveError;
         }
 


### PR DESCRIPTION
## This PR

- Makes failed coordinate->algebraic conversion return early from `playMove` with error object.
- Bumps patch version.