### PR TITLE
(v2.0.0): Return played move with error object/null in `Chess.prototype.playMove`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Returns full move count for current position.
 
 Returns current castling rights for each player.
 
-### playMove(move: string | { from: string, to: string }): Error | null
+### playMove(move: string | { from: string, to: string }): \[Error | null, string\]
 
-Makes the active player play the provided move if possible. If successful, returns null. If unsuccessful, returns an Error object.
+Makes the active player play the provided move if possible. Returns an array with an Error object and empty string if unsuccessful, or null and played algebraic move if successful.
 
 Moves can be provided as a full algebraic move as a string (e.g. 'e4' / 'Nf3' / 'Bxc6' / 'O-O') or as an object with a "from" coordinate and "to" coordinate, given in algebraic notation (e.g. { from: 'e1', to: 'g1' }). If given as an object, the resulting algebraic move will automatically include any castling, capture or disambiguating information.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chess-ts",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chess-ts",
-            "version": "1.2.1",
+            "version": "2.0.0",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maoshizhong/chess",
-    "version": "1.2.1",
+    "version": "2.0.0",
     "author": "MaoShizhong",
     "description": "Simple code-only Chessboard written in TypeScript. Handles FEN and PGN.",
     "repository": {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -403,25 +403,23 @@ describe('Error reporting', () => {
         );
     });
 
-    it('Returns null if move successfully played', () => {
+    it('Returns null and played moved if move successfully played', () => {
         const chess = new Chess(STARTING_POSITION);
         const e4Result = chess.playMove('e4');
-        expect(e4Result).toBe(null);
+        expect(e4Result).toEqual([null, 'e4']);
 
         const e5Result = chess.playMove('e5');
-        expect(e5Result).toBe(null);
+        expect(e5Result).toEqual([null, 'e5']);
     });
 
     it('Returns error if move not played', () => {
         const chess = new Chess(STARTING_POSITION);
-        const Kd1Result = chess.playMove('Kd1');
-        expect(Kd1Result).toBeInstanceOf(Error);
-        expect(Kd1Result?.message).toBe('Kd1 is not a valid move');
+        const [Kd1Error] = chess.playMove('Kd1');
+        expect(Kd1Error?.message).toBe('Kd1 is not a valid move');
 
         // https://lichess.org/analysis/8/8/8/8/2k5/1q6/8/K7_w_-_-_0_1
         const chess2 = new Chess('8/8/8/8/2k5/1q6/8/K7 w - - 0 1');
-        const Kb1Result = chess2.playMove('Kb1');
-        expect(Kb1Result).toBeInstanceOf(Error);
-        expect(Kb1Result?.message).toBe('Kb1 is not a valid move');
+        const [Kb1Error] = chess2.playMove('Kb1');
+        expect(Kb1Error?.message).toBe('Kb1 is not a valid move');
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ class Chess {
         };
     }
 
-    playMove(move: string | MoveCoordinates): Error | null {
+    playMove(move: string | MoveCoordinates): [Error | null, string] {
         // TODO: replace falsy expression with coordinates->toAlgebraic method call
         const [couldConvertToAlgebraic, algebraicMove] =
             typeof move === 'string'
@@ -87,7 +87,7 @@ class Chess {
         );
 
         if (!couldConvertToAlgebraic || !this.isGameInPlay) {
-            return invalidMoveError;
+            return [invalidMoveError, ''];
         }
 
         const [
@@ -97,7 +97,7 @@ class Chess {
             checksOpponent,
         ] = this.activePlayer.move(algebraicMove);
         if (!moveWasPlayed) {
-            return invalidMoveError;
+            return [invalidMoveError, ''];
         }
 
         this.#halfMoves = isCaptureOrPawnMove ? 0 : this.#halfMoves + 1;
@@ -126,7 +126,7 @@ class Chess {
 
             isThreefoldRepetition = this.history.isThreefoldRepetition();
             if (this.#halfMoves < 100 && !isThreefoldRepetition) {
-                return null;
+                return [null, algebraicMove];
             }
         }
 
@@ -151,7 +151,7 @@ class Chess {
                 this.result
             );
         }
-        return null;
+        return [null, algebraicMove];
     }
 
     toPreviousPosition(): Chess {
@@ -203,8 +203,8 @@ class Chess {
     #constructFromPGN(PGNString: string): void {
         const moves = PGN.getMoves(PGNString);
         for (const move of moves) {
-            const result = this.playMove(move);
-            if (result instanceof Error) {
+            const [error] = this.playMove(move);
+            if (error) {
                 throw new Error(`Invalid PGN - could not play ${move}`);
             }
         }


### PR DESCRIPTION
## This PR

- Has `Chess.prototype.playMove` return an error/playedMove array.
- Updates relevant tests
- Updates playMove documentation