### PR TITLE
Fix conversion for move coordinates for non-capture pawn moves across different files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "chess-ts",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "chess-ts",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "devDependencies": {
                 "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@maoshizhong/chess",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "author": "MaoShizhong",
     "description": "Simple code-only Chessboard written in TypeScript. Handles FEN and PGN.",
     "repository": {

--- a/src/parsers/algebraic.test.ts
+++ b/src/parsers/algebraic.test.ts
@@ -317,5 +317,18 @@ describe('Converting to algebraic notation', () => {
                 algebraic.toFullAlgebraicMove({ from, to }, boards[board])
             ).toEqual([true, result]);
         });
+
+        it.each([
+            ['e2', 'f4', 'starting board'],
+            ['a7', 'g5', 'starting board'],
+            ['a7', 'g6', 'starting board'],
+        ])(
+            "Does not convert pawn move from %s->%s on the %s (move doesn't exist)",
+            (from, to, board) => {
+                expect(
+                    algebraic.toFullAlgebraicMove({ from, to }, boards[board])
+                ).toEqual([false, '']);
+            }
+        );
     });
 });

--- a/src/parsers/algebraic.ts
+++ b/src/parsers/algebraic.ts
@@ -35,7 +35,13 @@ export function toFullAlgebraicMove(
 
     const pieceLetter = pieceToMove.letter.toUpperCase();
     if (pieceLetter === 'P') {
-        return [true, isCapture ? `${from[0]}x${to}` : to];
+        const destination = isCapture ? `${from[0]}x${to}` : to;
+        // Without this check, e2->f4 will be converted to f4, but that move is never possible
+        // Captures will still convert but will fail in the player move validation
+        // But non-capture nonsensical pawn moves should never be converted due to lack of disambiguators
+        return fromFile === toFile || isCapture
+            ? [true, destination]
+            : [false, ''];
     } else if (pieceLetter === 'K' && fromFile - toFile === 2) {
         return [true, 'O-O-O'];
     } else if (pieceLetter === 'K' && fromFile - toFile === -2) {


### PR DESCRIPTION
e2->f4 (starting position) was converting to f4, which does not contain enough information to disambiguate and fail player move validation. Hence this should fail during conversion. Captures contain enough information to invalidate during player move, so they can be left as is.

## This PR

- Prevents different-file non-capture pawn moves from being converted to algebraic notation