### PR TITLE
Fix threefold repetition not being serialised in PGN

### DIFF
--- a/src/game.test.ts
+++ b/src/game.test.ts
@@ -66,3 +66,25 @@ it('Continues from a game midway', () => {
         'rnb1k1nr/ppp3pp/5P2/8/1BPq4/8/PP4PP/RN3BKR w kq - 1 11'
     );
 });
+
+it('Plays an amazing game', () => {
+    const chess = new Chess();
+    chess.playMove('e4');
+    chess.playMove('e5');
+    chess.playMove('Ke2');
+    chess.playMove('Ke7');
+    chess.playMove('Ke1');
+    chess.playMove('Ke8');
+    chess.playMove('Ke2');
+    chess.playMove('Ke7');
+    chess.playMove('Ke1');
+    chess.playMove('Ke8'); // threefold repetition!
+    chess.playMove('Ke2'); // threefold repetition!
+
+    expect(chess.toPGN()).toBe(
+        '1. e4 e5 2. Ke2 Ke7 3. Ke1 Ke8 4. Ke2 Ke7 5. Ke1 Ke8 1/2-1/2'
+    );
+    expect(chess.toFEN()).toBe(
+        'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w - - 8 6'
+    );
+});

--- a/src/history/history.ts
+++ b/src/history/history.ts
@@ -1,4 +1,10 @@
-import { History, HistorySegments, HistoryState, Result } from '../types';
+import {
+    History,
+    HistoryEntry,
+    HistorySegments,
+    HistoryState,
+    Result,
+} from '../types';
 import * as FEN from '../parsers/FEN';
 import * as PGN from '../parsers/PGN';
 import { Chessboard } from '../board/board';
@@ -90,6 +96,10 @@ export class ChessHistory {
             move: move,
             result: result,
         });
+    }
+
+    markAsDraw(): void {
+        (this.#history[this.length - 1] as HistoryEntry).result = '1/2-1/2';
     }
 
     isThreefoldRepetition(): boolean {

--- a/src/parsers/PGN.test.ts
+++ b/src/parsers/PGN.test.ts
@@ -85,6 +85,17 @@ const stalemate: History = [
     ...lastMovePosition,
     { FEN: '8/8/8/8/8/1Q6/2K5/k7 b - - 1 1', move: 'Kc2', result: '1/2-1/2' },
 ];
+const threefoldRepetition: History = [
+    ...lastMovePosition,
+    { FEN: '8/8/8/8/1Q6/2K5/8/k7 b - - 1 1', move: 'Qb4' },
+    { FEN: '8/8/8/8/1Q6/2K5/k7/8 w - - 2 2', move: 'Ka2' },
+    { FEN: '8/8/8/8/8/1QK5/k7/8 b - - 3 2', move: 'Qb3+' },
+    { FEN: '8/8/8/8/8/1QK5/8/k7 w - - 4 3', move: 'Ka1' },
+    { FEN: '8/8/8/8/1Q6/2K5/8/k7 b - - 5 3', move: 'Qb4' },
+    { FEN: '8/8/8/8/1Q6/2K5/k7/8 w - - 6 4', move: 'Ka2' },
+    { FEN: '8/8/8/8/8/1QK5/k7/8 b - - 7 4', move: 'Qb3+' },
+    { FEN: '8/8/8/8/8/1QK5/8/k7 w - - 8 5', move: 'Ka1', result: '1/2-1/2' },
+];
 
 describe('Serialising', () => {
     it('Serialises single move from white', () => {
@@ -146,6 +157,9 @@ describe('Serialising', () => {
     it('Appends result if game is over', () => {
         expect(PGN.serialise(checkmate).endsWith('1-0')).toBe(true);
         expect(PGN.serialise(stalemate).endsWith('1/2-1/2')).toBe(true);
+        expect(PGN.serialise(threefoldRepetition).endsWith('1/2-1/2')).toBe(
+            true
+        );
     });
 });
 


### PR DESCRIPTION
Threefold repetition was not actually recording the result in history, only setting the `result` in the main Chess instance. This all worked fine functionally but would not include the result when serialised to PGN, which only reads the history. This also affected halfMoves draws.

## This PR

- Records draw result in final history state upon threefold repetition or halfMove draws.
- Adds tests for this case.