### PR TITLE
Add `getLegalMoves` method to main Chess export

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Makes the active player play the provided move if possible. Returns an array wit
 
 Moves can be provided as a full algebraic move as a string (e.g. 'e4' / 'Nf3' / 'Bxc6' / 'O-O') or as an object with a "from" coordinate and "to" coordinate, given in algebraic notation (e.g. { from: 'e1', to: 'g1' }), with an optional promotion letter (only Q/R/B/N are accepted). If given as an object, the resulting algebraic move will automatically include any castling, capture or disambiguating information. If a promotion letter is provided, it will only be used for pawn moves to the corresponding promotion rank.
 
+### getLegalMoves(square: string): string[]
+
+Returns an array containing all algebraic coordinates the selected piece can legally move to (piece/capture information omitted e.g. if `dxe6` is possible, `d6` will be included). Accounts for the game state (castling rights, castling through check, king in check etc.).
+
+Returns empty array if the selected square is empty or if the game has ended and you are viewing the latest position.
+
 ### toNthPosition(n: number): Chess
 
 Moves to specified history state (0-indexed) if available, and loads all position details (e.g. active player, half moves etc.) of that position. Sets latest position if n is greater or equal to the history length, and sets first position if n is less than 0. Mutates instance and returns `this`.

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -13,8 +13,7 @@ import { Pawn } from '../pieces/pawn';
 import { King } from '../pieces/king';
 import { Rook } from '../pieces/rook';
 
-// Infinity to make ranks 1-indexed
-export const RANK = [Infinity, 7, 6, 5, 4, 3, 2, 1, 0];
+export const RANK = [8, 7, 6, 5, 4, 3, 2, 1, 0];
 export const FILE: {
     [key: string]: number;
 } = { a: 0, b: 1, c: 2, d: 3, e: 4, f: 5, g: 6, h: 7 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -443,3 +443,62 @@ describe('Error reporting', () => {
         expect(Kb1Error?.message).toBe('Kb1 is not a valid move');
     });
 });
+
+describe('Showing legal moves', () => {
+    const boards = {
+        starting: STARTING_POSITION,
+        open: 'rnbqkbnr/4pp1p/pp1p2p1/2p4P/4P3/1P6/P1PP1PP1/RNBQKBNR w KQkq - 0 2',
+        enPassant:
+            'rnbqkbnr/2p1p1p1/p2p3p/1pP1Pp2/8/7P/PP1P1PP1/RNBQKBNR w KQkq f6 0 6',
+        check: 'rnb1kbnr/pppp1ppp/8/4p3/4P2q/5P2/PPPP2PP/RNBQKBNR w KQkq - 1 3',
+        castle: '5k2/8/8/8/8/8/8/4K2R w K - 0 1',
+        noCastle: '5k2/8/8/8/8/8/8/4K2R w - - 0 1',
+        castleThroughCheck: '5k2/8/8/8/2b5/8/8/4K2R w K - 0 1',
+        blackMove:
+            'r3k2r/pppp1ppp/6n1/4p3/4P3/2N5/PPPP1PPP/R1BQKBNR b KQkq - 1 2',
+    };
+
+    it.each([
+        ['e2', boards.starting, ['e3', 'e4']],
+        ['c2', boards.starting, ['c3', 'c4']],
+        ['b3', boards.open, ['b4']],
+        ['h5', boards.open, ['h6', 'g6']],
+        ['f1', boards.open, ['e2', 'd3', 'c4', 'b5', 'a6']],
+        ['h1', boards.open, ['h2', 'h3', 'h4']],
+        ['e5', boards.enPassant, ['e6', 'f6', 'd6']],
+        ['c5', boards.enPassant, ['c6', 'd6']],
+        ['g1', boards.check, []],
+        ['a2', boards.check, []],
+        ['e1', boards.check, ['e2']],
+        ['g2', boards.check, ['g3']],
+        ['e1', boards.castle, ['d1', 'd2', 'e2', 'f2', 'f1', 'g1']],
+        ['e1', boards.noCastle, ['d1', 'd2', 'e2', 'f2', 'f1']],
+        ['e1', boards.castleThroughCheck, ['d1', 'd2', 'f2']],
+        ['d7', boards.blackMove, ['d6', 'd5']],
+        ['g6', boards.blackMove, ['e7', 'f4', 'h4', 'f8']],
+        ['e8', boards.blackMove, ['c8', 'd8', 'e7', 'f8', 'g8']],
+    ])(
+        'Returns all legal moves for a piece given a board position',
+        (square, startingFEN, validMoves) => {
+            const chess = new Chess(startingFEN);
+            expect(chess.getLegalMoves(square).sort()).toEqual(
+                validMoves.sort()
+            );
+        }
+    );
+
+    it('Does not show possible moves after game has ended', () => {
+        const chess = new Chess('7k/8/5K2/6Q1/8/8/8/8 w - - 0 1');
+
+        chess.playMove('Qg7');
+        expect(chess.getLegalMoves('h8')).toEqual([]);
+    });
+
+    it('Shows legal moves after game has ended if not viewing latest position', () => {
+        const chess = new Chess('7k/8/5K2/6Q1/8/8/8/8 w - - 0 1');
+
+        chess.playMove('Qg7');
+        chess.toPreviousPosition();
+        expect(chess.getLegalMoves('h8')).toEqual(['h7']);
+    });
+});


### PR DESCRIPTION
Allows package consumers to easily get legal moves for any given square since an external manual implementation would be required otherwise (since position-aware legal moves requires simulating of playing those moves - not possible without simulation and checking for checks etc.)

## This PR

- Adds tests for getting legal moves for a square
- Implements `Chess.prototype.getLegalMoves` method
- Updates docs with new method
- Fixes `algebraic.toAlgebraic` converting rank 8 to `Infinity` by mistake